### PR TITLE
fix refresh by not editing data in place

### DIFF
--- a/.run/Run application.run.xml
+++ b/.run/Run application.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run application" type="CompoundRunConfigurationType">
+    <toRun name="dev" type="js.build_tools.npm" />
+    <toRun name="emulators" type="js.build_tools.npm" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/components/GameVersionBadge.tsx
+++ b/src/components/GameVersionBadge.tsx
@@ -22,8 +22,10 @@ const GameVersionBadge: React.FC<GameVersionBadgeProps> = ({
   const { segments } = version.badge;
   const localizedSegments: GameVersionBadgeSegment[] = segments.map(
     (segment) => {
-      segment.text = getLocalizedBadgeLabel(t, version?.id, segment.text);
-      return segment;
+      return {
+        ...segment,
+        text: getLocalizedBadgeLabel(t, version?.id, segment.text),
+      };
     },
   );
   const localizedName = getLocalizedGameName(

--- a/src/services/gameLocalization.ts
+++ b/src/services/gameLocalization.ts
@@ -87,7 +87,6 @@ export const getLocalizedSelectionLabel = (
   versionId: string | undefined,
   label: string,
 ) => {
-  if (!versionId) return label;
   const key = toKey(versionId, `selection.${normalizeLabel(label)}`);
   return key ? t(key, { defaultValue: label }) : label;
 };
@@ -97,7 +96,6 @@ export const getLocalizedBadgeLabel = (
   versionId: string | undefined,
   label: string,
 ) => {
-  if (!versionId) return label;
   const key = toKey(versionId, `badge.${normalizeLabel(label)}`);
   return key ? t(key, { defaultValue: label }) : label;
 };


### PR DESCRIPTION
- remove unnecessary checks in gameLocalization.ts
- add Compound run application

Problem was that I edited the segment objects text in place f.E. SM -> EM and then the application would have needed to map EM -> SM which obviously doesn't make sense. Now it just returns a new object with the correct text labels.