### PR TITLE
225 reevaluate level cap system details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import type {
   Pokemon,
   PokemonLink,
   RivalCap,
+  RivalCensorMode,
   RivalGender,
   Ruleset,
   TrackerMeta,
@@ -658,6 +659,14 @@ const App: React.FC = () => {
           safe.legendaryTrackerEnabled ?? base.legendaryTrackerEnabled ?? true,
         rivalCensorEnabled:
           safe.rivalCensorEnabled ?? base.rivalCensorEnabled ?? true,
+        rivalCensorMode:
+          safe.rivalCensorMode ??
+          base.rivalCensorMode ??
+          (safe.rivalCensorEnabled === false
+            ? "off"
+            : safe.rivalCensorEnabled === true
+              ? "on"
+              : "on"),
         hardcoreModeEnabled:
           safe.hardcoreModeEnabled ?? base.hardcoreModeEnabled ?? true,
         infiniteFossilsEnabled:
@@ -1218,6 +1227,7 @@ const App: React.FC = () => {
         // keep toggled settings
         legendaryTrackerEnabled: prev.legendaryTrackerEnabled,
         rivalCensorEnabled: prev.rivalCensorEnabled,
+        rivalCensorMode: prev.rivalCensorMode,
         hardcoreModeEnabled: prev.hardcoreModeEnabled,
         infiniteFossilsEnabled: prev.infiniteFossilsEnabled,
         megaStoneSpriteStyle: prev.megaStoneSpriteStyle,
@@ -1683,9 +1693,13 @@ const App: React.FC = () => {
     setData((prev) => ({ ...prev, legendaryTrackerEnabled: enabled }));
   };
 
-  const handleRivalCensorToggle = (enabled: boolean) => {
+  const handleRivalCensorToggle = (mode: RivalCensorMode) => {
     if (isReadOnly) return;
-    setData((prev) => ({ ...prev, rivalCensorEnabled: enabled }));
+    setData((prev) => ({
+      ...prev,
+      rivalCensorMode: mode,
+      rivalCensorEnabled: mode !== "off",
+    }));
   };
 
   const handleHardcoreModeToggle = (enabled: boolean) => {
@@ -2399,8 +2413,11 @@ const App: React.FC = () => {
       onBack={closeSettingsPanel}
       legendaryTrackerEnabled={data.legendaryTrackerEnabled ?? true}
       onlegendaryTrackerToggle={handleLegendaryTrackerToggle}
-      rivalCensorEnabled={data.rivalCensorEnabled ?? true}
-      onRivalCensorToggle={handleRivalCensorToggle}
+      rivalCensorMode={
+        data.rivalCensorMode ??
+        (data.rivalCensorEnabled === false ? "off" : "on")
+      }
+      onRivalCensorModeChange={handleRivalCensorToggle}
       hardcoreModeEnabled={data.hardcoreModeEnabled ?? true}
       onHardcoreModeToggle={handleHardcoreModeToggle}
       infiniteFossilsEnabled={data.infiniteFossilsEnabled ?? false}
@@ -2739,6 +2756,10 @@ const App: React.FC = () => {
               onRulesChange={(rules) => setData((prev) => ({ ...prev, rules }))}
               legendaryTrackerEnabled={data.legendaryTrackerEnabled ?? true}
               rivalCensorEnabled={data.rivalCensorEnabled ?? true}
+              rivalCensorMode={
+                data.rivalCensorMode ??
+                (data.rivalCensorEnabled === false ? "off" : "on")
+              }
               hardcoreModeEnabled={data.hardcoreModeEnabled ?? true}
               onlegendaryIncrement={handleLegendaryIncrement}
               onlegendaryDecrement={handleLegendaryDecrement}

--- a/src/components/other/GameImages.tsx
+++ b/src/components/other/GameImages.tsx
@@ -6,8 +6,9 @@ import { getSpriteUrlForPokemonName } from "@/src/services/sprites.ts";
 export const RivalImage: React.FC<{
   rival: string | VariableRival;
   preferences: UserSettings["rivalPreferences"];
+  defaultPreferences?: Record<string, string>;
   displayName?: string;
-}> = ({ rival, preferences, displayName }) => {
+}> = ({ rival, preferences, defaultPreferences, displayName }) => {
   let spriteName: string;
   let fallbackDisplayName: string;
 
@@ -19,7 +20,8 @@ export const RivalImage: React.FC<{
       .replace(/[^a-z0-9_]/g, "");
     fallbackDisplayName = rival;
   } else {
-    const preference = preferences?.[rival.key] || "male";
+    const preference =
+      preferences?.[rival.key] ?? defaultPreferences?.[rival.key] ?? "male";
     spriteName = rival.options[preference];
     fallbackDisplayName = rival.key;
   }

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/src/services/init.ts";
 import type {
   GameVersion,
+  RivalCensorMode,
   RivalGender,
   Ruleset,
   TrackerMember,
@@ -32,6 +33,7 @@ import {
   focusRingRedClasses,
 } from "@/src/styles/focusRing.ts";
 import ToggleSwitch from "@/src/components/toggles/ToggleSwitch.tsx";
+import TriStateToggle from "@/src/components/toggles/TriStateToggle.tsx";
 import Tooltip from "@/src/components/other/Tooltip.tsx";
 import { useTranslation } from "react-i18next";
 import { getLocalizedRivalEntry } from "@/src/services/gameLocalization.ts";
@@ -49,8 +51,8 @@ interface SettingsPageProps {
   onBack: () => void;
   legendaryTrackerEnabled: boolean;
   onlegendaryTrackerToggle: (enabled: boolean) => void;
-  rivalCensorEnabled: boolean;
-  onRivalCensorToggle: (enabled: boolean) => void;
+  rivalCensorMode: RivalCensorMode;
+  onRivalCensorModeChange: (mode: RivalCensorMode) => void;
   hardcoreModeEnabled: boolean;
   onHardcoreModeToggle: (enabled: boolean) => void;
   infiniteFossilsEnabled: boolean;
@@ -86,8 +88,8 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   onBack,
   legendaryTrackerEnabled,
   onlegendaryTrackerToggle,
-  rivalCensorEnabled,
-  onRivalCensorToggle,
+  rivalCensorMode,
+  onRivalCensorModeChange,
   hardcoreModeEnabled,
   onHardcoreModeToggle,
   infiniteFossilsEnabled,
@@ -389,6 +391,54 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                 <div>
                   <div className="flex items-center gap-2">
                     <div className="font-medium text-gray-800 dark:text-gray-200">
+                      {t("settings.features.rivalCensor.title")}
+                    </div>
+                    <Tooltip
+                      side="top"
+                      content={t("settings.features.rivalCensor.tooltip")}
+                    >
+                      <span
+                        className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 cursor-help"
+                        aria-label={t(
+                          "settings.features.rivalCensor.tooltipLabel",
+                        )}
+                      >
+                        <FiInfo size={16} />
+                      </span>
+                    </Tooltip>
+                  </div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400">
+                    {t("settings.features.rivalCensor.description")}
+                  </div>
+                </div>
+                <TriStateToggle
+                  id="rival-censor-toggle"
+                  value={rivalCensorMode}
+                  options={[
+                    {
+                      value: "off" as const,
+                      label: t("settings.features.rivalCensor.modes.off"),
+                    },
+                    {
+                      value: "showLevels" as const,
+                      label: t(
+                        "settings.features.rivalCensor.modes.showLevels",
+                      ),
+                    },
+                    {
+                      value: "on" as const,
+                      label: t("settings.features.rivalCensor.modes.on"),
+                    },
+                  ]}
+                  onChange={onRivalCensorModeChange}
+                  ariaLabel={t("settings.features.rivalCensor.title")}
+                  disabled={isGuest}
+                />
+              </div>
+              <div className="flex items-center justify-between mb-4">
+                <div>
+                  <div className="flex items-center gap-2">
+                    <div className="font-medium text-gray-800 dark:text-gray-200">
                       {t("settings.features.hardcore.title")}
                     </div>
                     <Tooltip
@@ -414,38 +464,6 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                   checked={hardcoreModeEnabled}
                   onChange={onHardcoreModeToggle}
                   ariaLabel={t("settings.features.hardcore.title")}
-                  disabled={isGuest}
-                />
-              </div>
-              <div className="flex items-center justify-between mb-4">
-                <div>
-                  <div className="flex items-center gap-2">
-                    <div className="font-medium text-gray-800 dark:text-gray-200">
-                      {t("settings.features.rivalCensor.title")}
-                    </div>
-                    <Tooltip
-                      side="top"
-                      content={t("settings.features.rivalCensor.tooltip")}
-                    >
-                      <span
-                        className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 cursor-help"
-                        aria-label={t(
-                          "settings.features.rivalCensor.tooltipLabel",
-                        )}
-                      >
-                        <FiInfo size={16} />
-                      </span>
-                    </Tooltip>
-                  </div>
-                  <div className="text-xs text-gray-500 dark:text-gray-400">
-                    {t("settings.features.rivalCensor.description")}
-                  </div>
-                </div>
-                <ToggleSwitch
-                  id="rival-censor-toggle"
-                  checked={rivalCensorEnabled}
-                  onChange={onRivalCensorToggle}
-                  ariaLabel={t("settings.features.rivalCensor.title")}
                   disabled={isGuest}
                 />
               </div>

--- a/src/components/pages/SettingsPage.tsx
+++ b/src/components/pages/SettingsPage.tsx
@@ -583,20 +583,24 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                         <input
                           type="radio"
                           name={`rival-${rival.key}`}
-                          value="male"
+                          value="female"
                           checked={
-                            (rivalPreferences?.[rival.key] || "male") === "male"
+                            (rivalPreferences?.[rival.key] ??
+                              gameVersion?.defaultRivalPreferences?.[
+                                rival.key
+                              ] ??
+                              "male") === "female"
                           }
                           onChange={() =>
-                            onRivalPreferenceChange(rival.key, "male")
+                            onRivalPreferenceChange(rival.key, "female")
                           }
                           disabled={isGuest}
                           className="h-4 w-4 accent-green-600 disabled:opacity-60"
                         />{" "}
                         {getRivalOptionLabel(
                           rival.key,
-                          "male",
-                          rival.options.male,
+                          "female",
+                          rival.options.female,
                         )}
                       </label>
                       <label
@@ -609,18 +613,24 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                         <input
                           type="radio"
                           name={`rival-${rival.key}`}
-                          value="female"
-                          checked={rivalPreferences?.[rival.key] === "female"}
+                          value="male"
+                          checked={
+                            (rivalPreferences?.[rival.key] ??
+                              gameVersion?.defaultRivalPreferences?.[
+                                rival.key
+                              ] ??
+                              "male") === "male"
+                          }
                           onChange={() =>
-                            onRivalPreferenceChange(rival.key, "female")
+                            onRivalPreferenceChange(rival.key, "male")
                           }
                           disabled={isGuest}
                           className="h-4 w-4 accent-green-600 disabled:opacity-60"
                         />{" "}
                         {getRivalOptionLabel(
                           rival.key,
-                          "female",
-                          rival.options.female,
+                          "male",
+                          rival.options.male,
                         )}
                       </label>
                     </div>

--- a/src/components/toggles/TriStateToggle.tsx
+++ b/src/components/toggles/TriStateToggle.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+
+export interface TriStateOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+export interface TriStateToggleProps<T extends string> {
+  id: string;
+  value: T;
+  options: TriStateOption<T>[];
+  onChange: (value: T) => void;
+  ariaLabel?: string;
+  disabled?: boolean;
+}
+
+function TriStateToggle<T extends string>({
+  id,
+  value,
+  options,
+  onChange,
+  ariaLabel,
+  disabled,
+}: TriStateToggleProps<T>) {
+  const selectedIndex = options.findIndex((o) => o.value === value);
+
+  return (
+    <div
+      id={id}
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={`inline-flex rounded-md border border-gray-300 dark:border-gray-600 overflow-hidden ${disabled ? "opacity-60 pointer-events-none" : ""}`}
+    >
+      {options.map((option, index) => {
+        const isActive = index === selectedIndex;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            onClick={() => onChange(option.value)}
+            disabled={disabled}
+            className={`px-2.5 py-1 text-xs font-semibold transition-colors duration-150 ${
+              isActive
+                ? "bg-green-600 text-white"
+                : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700"
+            } ${index > 0 ? "border-l border-gray-300 dark:border-gray-600" : ""}`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default TriStateToggle;

--- a/src/components/widgets/InfoPanel.tsx
+++ b/src/components/widgets/InfoPanel.tsx
@@ -3,6 +3,7 @@ import type {
   GameVersion,
   LevelCap,
   RivalCap,
+  RivalCensorMode,
   Stats,
   UserSettings,
 } from "@/types.ts";
@@ -33,6 +34,7 @@ interface InfoPanelProps {
   onRulesChange: (rules: string[]) => void;
   legendaryTrackerEnabled: boolean;
   rivalCensorEnabled: boolean;
+  rivalCensorMode?: RivalCensorMode;
   hardcoreModeEnabled: boolean;
   onlegendaryIncrement: () => void;
   onlegendaryDecrement: () => void;
@@ -59,6 +61,7 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
   onRulesChange,
   legendaryTrackerEnabled,
   rivalCensorEnabled,
+  rivalCensorMode,
   hardcoreModeEnabled,
   onlegendaryIncrement,
   onlegendaryDecrement,
@@ -102,6 +105,7 @@ const InfoPanel: React.FC<InfoPanelProps> = ({
           onRivalCapToggleDone={onRivalCapToggleDone}
           onRivalCapReveal={onRivalCapReveal}
           rivalCensorEnabled={rivalCensorEnabled}
+          rivalCensorMode={rivalCensorMode}
           hardcoreModeEnabled={hardcoreModeEnabled}
           gameVersion={gameVersion}
           rivalPreferences={rivalPreferences}

--- a/src/components/widgets/Levelcaps.tsx
+++ b/src/components/widgets/Levelcaps.tsx
@@ -127,7 +127,10 @@ const Levelcaps: React.FC<LevelcapsProps> = ({
     if (typeof cap.rival !== "object") {
       return baseName;
     }
-    const preference = rivalPreferences?.[cap.rival.key] || "male";
+    const preference =
+      rivalPreferences?.[cap.rival.key] ??
+      gameVersion?.defaultRivalPreferences?.[cap.rival.key] ??
+      "male";
     const localizedEntry = getLocalizedRivalEntry(t, cap.rival);
     const localizedOptions: Record<"male" | "female", string> | undefined =
       localizedEntry &&
@@ -360,6 +363,7 @@ const Levelcaps: React.FC<LevelcapsProps> = ({
                 <RivalImage
                   rival={cap.rival}
                   preferences={rivalPreferences}
+                  defaultPreferences={gameVersion?.defaultRivalPreferences}
                   displayName={resolvePreferredRivalName(cap)}
                 />
                 <span className="font-bold text-lg text-gray-800 dark:text-gray-200 text-center">

--- a/src/components/widgets/Levelcaps.tsx
+++ b/src/components/widgets/Levelcaps.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect, useState } from "react";
-import type { GameVersion, LevelCap, RivalCap, UserSettings } from "@/types.ts";
+import type {
+  GameVersion,
+  LevelCap,
+  RivalCap,
+  RivalCensorMode,
+  UserSettings,
+} from "@/types.ts";
 import { BadgeImage, RivalImage } from "@/src/components/other/GameImages.tsx";
 import { FiEye, FiEyeOff, FiRefreshCw } from "react-icons/fi";
 import { useTranslation } from "react-i18next";
@@ -22,6 +28,7 @@ interface LevelcapsProps {
   onRivalCapToggleDone: (index: number) => void;
   onRivalCapReveal: (index: number) => void;
   rivalCensorEnabled: boolean;
+  rivalCensorMode?: RivalCensorMode;
   hardcoreModeEnabled: boolean;
   gameVersion?: GameVersion;
   rivalPreferences: UserSettings["rivalPreferences"];
@@ -45,6 +52,7 @@ const Levelcaps: React.FC<LevelcapsProps> = ({
   onRivalCapToggleDone,
   onRivalCapReveal,
   rivalCensorEnabled,
+  rivalCensorMode,
   hardcoreModeEnabled,
   gameVersion,
   rivalPreferences,
@@ -59,7 +67,11 @@ const Levelcaps: React.FC<LevelcapsProps> = ({
     readStoredCapsView(trackerViewStorageKey),
   );
   const [isMobile, setIsMobile] = useState(false);
-  const nextRivalToRevealIndex = rivalCensorEnabled
+  const effectiveCensorMode: RivalCensorMode =
+    rivalCensorMode ?? (rivalCensorEnabled ? "on" : "off");
+  const isCensored = effectiveCensorMode !== "off";
+  const showLevelsWhileCensored = effectiveCensorMode === "showLevels";
+  const nextRivalToRevealIndex = isCensored
     ? rivalCaps.findIndex((cap) => !cap.revealed)
     : -1;
   const versionId = gameVersion?.id;
@@ -246,76 +258,115 @@ const Levelcaps: React.FC<LevelcapsProps> = ({
       {rivalCaps.map((cap, index) => {
         const isRivalCapActive =
           isVisible && !readOnly && canToggleRivalAtIndex(rivalCaps, index);
-        return (
-          <div key={cap.id}>
-            {rivalCensorEnabled && !cap.revealed ? (
-              <>
-                {index === nextRivalToRevealIndex && !readOnly ? (
-                  <button
-                    onClick={() => {
-                      onRivalCapReveal(index);
-                    }}
-                    tabIndex={isVisible ? 0 : -1}
-                    className="w-full flex items-center justify-center gap-2 text-sm p-3 rounded-md border bg-gray-100 dark:bg-gray-700/50 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300 border-gray-200 dark:border-gray-600"
-                  >
-                    <FiEye size={16} /> {t("tracker.infoPanel.nextRival")}
-                  </button>
+        const isHidden = isCensored && !cap.revealed;
+        const canReveal =
+          isHidden && index === nextRivalToRevealIndex && !readOnly;
+
+        if (isHidden) {
+          const bgClasses = canReveal
+            ? "bg-gray-100 dark:bg-gray-700/50 hover:bg-gray-200 dark:hover:bg-gray-700 border-gray-200 dark:border-gray-600"
+            : "bg-gray-50 dark:bg-gray-800 border-dashed border-gray-300 dark:border-gray-600";
+
+          const content = (
+            <>
+              <div className="flex items-center gap-3 grow min-w-0 h-8">
+                {canReveal ? (
+                  <FiEye
+                    size={16}
+                    className="shrink-0 text-gray-600 dark:text-gray-300"
+                  />
                 ) : (
-                  <div className="w-full flex items-center justify-center gap-2 text-sm p-3 rounded-md bg-gray-50 dark:bg-gray-800 text-gray-400 dark:text-gray-500 cursor-not-allowed border border-dashed border-gray-300 dark:border-gray-600">
-                    <FiEyeOff size={16} /> {t("tracker.infoPanel.futureBattle")}
-                  </div>
+                  <FiEyeOff
+                    size={16}
+                    className="shrink-0 text-gray-400 dark:text-gray-500"
+                  />
                 )}
-              </>
-            ) : (
-              <div
-                className={`flex items-center justify-between pl-2 py-1.5 border rounded-md ${cap.done ? "bg-green-100 dark:bg-green-900/50 border-green-200 dark:border-green-800" : "bg-gray-50 dark:bg-gray-700/50 border-gray-200 dark:border-gray-600"}`}
-              >
-                <div className="flex items-center gap-3 grow min-w-0">
-                  <input
-                    id={`rivalcap-done-${cap.id}`}
-                    type="checkbox"
-                    checked={!!cap.done}
-                    tabIndex={isRivalCapActive ? 0 : -1}
-                    onChange={() => attemptRivalToggle(index)}
-                    onClick={(event) => {
-                      if (
-                        readOnly ||
-                        !canToggleRivalAtIndex(rivalCaps, index)
-                      ) {
-                        event.preventDefault();
-                      }
-                    }}
-                    aria-label={t("tracker.infoPanel.completedArena", {
-                      target: resolvePreferredRivalName(cap),
-                    })}
-                    className={`h-5 w-5 accent-green-600 shrink-0 ${
-                      isRivalCapActive ? "cursor-pointer" : "cursor opacity-70"
-                    }`}
-                  />
-                  <span
-                    onClick={(event) => event.stopPropagation()}
-                    className="text-sm text-gray-800 dark:text-gray-300 wrap-break-word"
-                  >
-                    {getLocalizedRivalLocation(
-                      t,
-                      versionId,
-                      cap.id,
-                      cap.location,
-                    )}
-                  </span>
-                </div>
+                <span
+                  className={`text-sm ${canReveal ? "text-gray-600 dark:text-gray-300" : "text-gray-400 dark:text-gray-500"}`}
+                >
+                  {canReveal
+                    ? t("tracker.infoPanel.nextRival")
+                    : t("tracker.infoPanel.futureBattle")}
+                </span>
+              </div>
+              {showLevelsWhileCensored && (
                 <div className="flex items-center justify-end shrink-0 px-3">
-                  <RivalImage
-                    rival={cap.rival}
-                    preferences={rivalPreferences}
-                    displayName={resolvePreferredRivalName(cap)}
-                  />
                   <span className="font-bold text-lg text-gray-800 dark:text-gray-200 text-center">
                     {renderLevelCaps(cap.level)}
                   </span>
                 </div>
+              )}
+            </>
+          );
+
+          return (
+            <div key={cap.id}>
+              {canReveal ? (
+                <button
+                  onClick={() => onRivalCapReveal(index)}
+                  tabIndex={isVisible ? 0 : -1}
+                  className={`w-full flex items-center justify-between pl-2 py-1.5 border rounded-md ${bgClasses}`}
+                >
+                  {content}
+                </button>
+              ) : (
+                <div
+                  className={`flex items-center justify-between pl-2 py-1.5 border rounded-md cursor-not-allowed ${bgClasses}`}
+                >
+                  {content}
+                </div>
+              )}
+            </div>
+          );
+        }
+
+        return (
+          <div key={cap.id}>
+            <div
+              className={`flex items-center justify-between pl-2 py-1.5 border rounded-md ${cap.done ? "bg-green-100 dark:bg-green-900/50 border-green-200 dark:border-green-800" : "bg-gray-50 dark:bg-gray-700/50 border-gray-200 dark:border-gray-600"}`}
+            >
+              <div className="flex items-center gap-3 grow min-w-0">
+                <input
+                  id={`rivalcap-done-${cap.id}`}
+                  type="checkbox"
+                  checked={!!cap.done}
+                  tabIndex={isRivalCapActive ? 0 : -1}
+                  onChange={() => attemptRivalToggle(index)}
+                  onClick={(event) => {
+                    if (readOnly || !canToggleRivalAtIndex(rivalCaps, index)) {
+                      event.preventDefault();
+                    }
+                  }}
+                  aria-label={t("tracker.infoPanel.completedArena", {
+                    target: resolvePreferredRivalName(cap),
+                  })}
+                  className={`h-5 w-5 accent-green-600 shrink-0 ${
+                    isRivalCapActive ? "cursor-pointer" : "cursor opacity-70"
+                  }`}
+                />
+                <span
+                  onClick={(event) => event.stopPropagation()}
+                  className="text-sm text-gray-800 dark:text-gray-300 wrap-break-word"
+                >
+                  {getLocalizedRivalLocation(
+                    t,
+                    versionId,
+                    cap.id,
+                    cap.location,
+                  )}
+                </span>
               </div>
-            )}
+              <div className="flex items-center justify-end shrink-0 px-3">
+                <RivalImage
+                  rival={cap.rival}
+                  preferences={rivalPreferences}
+                  displayName={resolvePreferredRivalName(cap)}
+                />
+                <span className="font-bold text-lg text-gray-800 dark:text-gray-200 text-center">
+                  {renderLevelCaps(cap.level)}
+                </span>
+              </div>
+            </div>
           </div>
         );
       })}

--- a/src/data/game-versions.ts
+++ b/src/data/game-versions.ts
@@ -419,6 +419,7 @@ export const GAME_VERSIONS: Record<string, GameVersion> = {
   gen3_rusa: {
     id: "gen3_rusa",
     badgeSet: "gen3/rusaem",
+    defaultRivalPreferences: { brendan_may: "female" },
     badge: {
       segments: [
         {
@@ -568,6 +569,7 @@ export const GAME_VERSIONS: Record<string, GameVersion> = {
   gen3_em: {
     id: "gen3_em",
     badgeSet: "gen3/rusaem",
+    defaultRivalPreferences: { brendan_may: "female" },
     badge: {
       segments: [
         {
@@ -1732,6 +1734,7 @@ export const GAME_VERSIONS: Record<string, GameVersion> = {
   gen6_oras: {
     id: "gen6_oras",
     badgeSet: "gen3/rusaem",
+    defaultRivalPreferences: { brendan_may: "female" },
     badge: {
       segments: [
         {

--- a/src/data/game-versions.ts
+++ b/src/data/game-versions.ts
@@ -1537,6 +1537,7 @@ export const GAME_VERSIONS: Record<string, GameVersion> = {
   gen6_xy: {
     id: "gen6_xy",
     badgeSet: "gen6/xy",
+    defaultRivalPreferences: { calem_serena: "female" },
     badge: {
       segments: [
         {

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -506,9 +506,14 @@ export const de = {
       rivalCensor: {
         title: "Rivalenkämpfe zensieren",
         tooltipLabel: "Info Rivalenkämpfe zensieren",
-        tooltip: `Um Spoiler zu vermeiden und die Story besser genießen zu können, werden Rivalenkämpfe zensiert und müssen händisch aufgedeckt werden.\n\nNach einmaligem Aufdecken und auch in folgenden Runs bleiben sie dann aufgedeckt.`,
+        tooltip: `Um Spoiler zu vermeiden und die Story besser genießen zu können, werden Rivalenkämpfe zensiert und müssen händisch aufgedeckt werden.\n\nNach einmaligem Aufdecken und auch in folgenden Runs bleiben sie dann aufgedeckt. Du kannst auch nur die Level der anstehenden Rivalenkämpfen anzeigen lassen.`,
         description:
           "Verbirgt Details zu Rivalenkämpfen, bis sie aufgedeckt werden.",
+        modes: {
+          off: "Aus",
+          showLevels: "Zeige Level",
+          on: "An",
+        },
       },
       legendary: {
         title: "Legendary Tracker",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -502,8 +502,13 @@ export const en = {
       rivalCensor: {
         title: "Censor rival battles",
         tooltipLabel: "Rival info",
-        tooltip: `To avoid spoilers and keep the story fresh, rival battles are hidden and must be revealed manually.\n\nOnce uncovered they stay visible, even on future runs.`,
+        tooltip: `To avoid spoilers and keep the story fresh, rival battles are hidden and must be revealed manually.\n\nOnce uncovered they stay visible, even on future runs. You can also decide to only show the level of upcoming rival battles.`,
         description: "Hides rival battles until you reveal them manually.",
+        modes: {
+          off: "Off",
+          showLevels: "Show Levels",
+          on: "On",
+        },
       },
       legendary: {
         title: "Legendary tracker",

--- a/src/services/init.ts
+++ b/src/services/init.ts
@@ -91,7 +91,7 @@ export const INITIAL_STATE: AppState = {
   legendaryTrackerEnabled: true,
   rivalCensorEnabled: true,
   rivalCensorMode: "on",
-  hardcoreModeEnabled: true,
+  hardcoreModeEnabled: false,
   infiniteFossilsEnabled: false,
   megaStoneSpriteStyle: "item",
   fossils: [],

--- a/src/services/init.ts
+++ b/src/services/init.ts
@@ -90,6 +90,7 @@ export const INITIAL_STATE: AppState = {
   stats: ensureStatsForPlayers(undefined, DEFAULT_PLAYER_NAME_SET.length),
   legendaryTrackerEnabled: true,
   rivalCensorEnabled: true,
+  rivalCensorMode: "on",
   hardcoreModeEnabled: true,
   infiniteFossilsEnabled: false,
   megaStoneSpriteStyle: "item",

--- a/types.ts
+++ b/types.ts
@@ -70,6 +70,8 @@ export interface Stats {
   legendaryEncounters?: number;
 }
 
+export type RivalCensorMode = "off" | "showLevels" | "on";
+
 export interface AppState {
   playerNames: string[];
   team: PokemonLink[];
@@ -81,6 +83,8 @@ export interface AppState {
   rivalCaps: RivalCap[];
   stats: Stats;
   legendaryTrackerEnabled?: boolean;
+  rivalCensorMode?: RivalCensorMode;
+  /** @deprecated Use rivalCensorMode instead */
   rivalCensorEnabled?: boolean;
   hardcoreModeEnabled?: boolean;
   infiniteFossilsEnabled?: boolean;

--- a/types.ts
+++ b/types.ts
@@ -132,6 +132,7 @@ export interface GameVersion {
   selectionColors?: Record<string, GameSelectionColor>;
   levelCaps: Omit<LevelCap, "done">[];
   rivalCaps: Omit<RivalCap, "done" | "revealed">[];
+  defaultRivalPreferences?: Record<string, RivalGender>;
 }
 
 export interface TrackerMeta {


### PR DESCRIPTION
- added new TriStateToggle
- added option to show levels on rival censoring
- moved rival censor setting to the top
- fixed design, so all 3 states share the same design and dimensions
- changed level cap default from hardcore mode to normal
- changed default hoenn rival to May
- replaced old fallback logic with defaultRivalPreferences
- moved rival selection arround, so May is up front

<img width="648" height="435" alt="image" src="https://github.com/user-attachments/assets/737db400-dcc7-4cf2-9194-375aa4c57048" />