### PR TITLE
refactor font-face declarations to use consistent font paths

### DIFF
--- a/index.css
+++ b/index.css
@@ -4,17 +4,13 @@
 
 @font-face {
   font-family: "Press Start 2P";
-  src:
-    url("/dist/fonts/press-start-2p.woff2") format("woff2"),
-    url("/public/fonts/press-start-2p.woff2") format("woff2");
+  src: url("/fonts/press-start-2p.woff2") format("woff2");
   font-display: swap;
 }
 
 @font-face {
   font-family: "Roboto";
-  src:
-    url("/dist/fonts/Roboto-VariableFont.woff2") format("woff2"),
-    url("/public/fonts/Roboto-VariableFont.woff2") format("woff2");
+  src: url("/fonts/Roboto-VariableFont.woff2") format("woff2");
   font-weight: 100 900;
   font-style: normal;
   font-display: swap;
@@ -22,9 +18,7 @@
 
 @font-face {
   font-family: "Roboto";
-  src:
-    url("/dist/fonts/Roboto-VariableFont.woff2") format("woff2"),
-    url("/public/fonts/Roboto-Italic-VariableFont.woff2") format("woff2");
+  src: url("/fonts/Roboto-Italic-VariableFont.woff2") format("woff2");
   font-weight: 100 900;
   font-style: italic;
   font-display: swap;


### PR DESCRIPTION
Issue tested in **dev** and **prod**

**What went wrong:** The dual-URL approach was based on a misunderstanding of how Vite handles the `public/` directory. Vite serves `public/` files at the root path — so `public/fonts/foo.woff2` is accessible at `/fonts/foo.woff2` in **both** dev and production. There is no `/dist/` prefix in the deployed output, and `/public/` should never appear in source URLs. The font still worked because the browser's `src` fallback mechanism tried the second URL after the first 404'd - but it generated errors every time.