### PR TITLE
Add multi-language search feature with context and settings toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ import UserSettingsPage from "@/src/components/pages/UserSettingsPage.tsx";
 import PasswordResetPage from "@/src/components/pages/PasswordResetPage.tsx";
 import ResetModal from "@/src/components/modals/ResetModal.tsx";
 import EditPairModal from "@/src/components/modals/EditPairModal.tsx";
+import { MultiLocaleSearchContext } from "@/src/hooks/useMultiLocaleSearch.ts";
 import DarkModeToggle, {
   getDarkMode,
   setDarkMode,
@@ -88,12 +89,14 @@ import {
   deleteTracker,
   ensureUserProfile,
   getUserGenerationSpritePreference,
+  getUserMultiLocaleSearchPreference,
   getUserSpritesInTeamTablePreference,
   getUserWikiPreference,
   removeMemberFromTracker,
   TrackerOperationError,
   updateRivalPreference,
   updateUserGenerationSpritePreference,
+  updateUserMultiLocaleSearchPreference,
   updateUserSpritesInTeamTablePreference,
   updateUserWikiPreference,
 } from "@/src/services/trackers";
@@ -237,6 +240,7 @@ const App: React.FC = () => {
   const [userUseSpritesInTeamTable, setUserUseSpritesInTeamTable] =
     useState(false);
   const [userWikiId, setUserWikiId] = useState<string | null>(null);
+  const [userMultiLocaleSearch, setUserMultiLocaleSearch] = useState(false);
   const showSettings = searchParams.get("panel") === "settings";
   const openSettingsPanel = useCallback(() => {
     const next = new URLSearchParams(searchParams);
@@ -549,6 +553,22 @@ const App: React.FC = () => {
     [user],
   );
 
+  const handleMultiLocaleSearchToggle = useCallback(
+    async (enabled: boolean) => {
+      if (!user) return;
+      try {
+        await updateUserMultiLocaleSearchPreference(user.uid, enabled);
+        setUserMultiLocaleSearch(enabled);
+      } catch (error) {
+        console.error(
+          "Failed to update multi-locale search preference:",
+          error,
+        );
+      }
+    },
+    [user],
+  );
+
   const effectiveWikiId: WikiId =
     (userWikiId as WikiId | null) ??
     ((i18n.resolvedLanguage || i18n.language || "")
@@ -811,16 +831,19 @@ const App: React.FC = () => {
       getUserGenerationSpritePreference(user.uid),
       getUserSpritesInTeamTablePreference(user.uid),
       getUserWikiPreference(user.uid),
+      getUserMultiLocaleSearchPreference(user.uid),
     ])
-      .then(([genSprites, teamTableSprites, wikiId]) => {
+      .then(([genSprites, teamTableSprites, wikiId, multiLocale]) => {
         setUserUseGenerationSprites(genSprites);
         setUserUseSpritesInTeamTable(teamTableSprites);
         setUserWikiId(wikiId);
+        setUserMultiLocaleSearch(multiLocale);
       })
       .catch(() => {
         setUserUseGenerationSprites(false);
         setUserUseSpritesInTeamTable(false);
         setUserWikiId(null);
+        setUserMultiLocaleSearch(false);
       });
   }, [user]);
 
@@ -3002,7 +3025,7 @@ const App: React.FC = () => {
   );
 
   return (
-    <>
+    <MultiLocaleSearchContext.Provider value={userMultiLocaleSearch}>
       <CreateTrackerModal
         isOpen={showCreateModal}
         onClose={() => {
@@ -3097,6 +3120,8 @@ const App: React.FC = () => {
                 onSpritesInTeamTableToggle={handleSpritesInTeamTableToggle}
                 wikiId={userWikiId ?? effectiveWikiId}
                 onWikiChange={handleWikiChange}
+                multiLocaleSearch={userMultiLocaleSearch}
+                onMultiLocaleSearchToggle={handleMultiLocaleSearchToggle}
               />
             ) : (
               <Navigate to="/" replace />
@@ -3105,7 +3130,7 @@ const App: React.FC = () => {
         />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
-    </>
+    </MultiLocaleSearchContext.Provider>
   );
 };
 

--- a/src/components/inputs/ItemSuggestionInput.tsx
+++ b/src/components/inputs/ItemSuggestionInput.tsx
@@ -9,6 +9,7 @@ import {
 import { normalizeLanguage } from "@/src/utils/language";
 import SuggestionInput from "@/src/components/inputs/SuggestionInput.tsx";
 import ItemSprite from "@/src/components/other/ItemSprite.tsx";
+import { useMultiLocaleSearch } from "@/src/hooks/useMultiLocaleSearch.ts";
 
 interface ItemSuggestionInputProps {
   label?: React.ReactNode;
@@ -20,6 +21,7 @@ interface ItemSuggestionInputProps {
   gameVersionId?: string;
   allPokemonAndItems?: boolean;
   placeholder?: string;
+  multiLocaleSearch?: boolean;
 }
 
 const ItemSuggestionInput: React.FC<ItemSuggestionInputProps> = ({
@@ -32,20 +34,24 @@ const ItemSuggestionInput: React.FC<ItemSuggestionInputProps> = ({
   gameVersionId,
   allPokemonAndItems = false,
   placeholder,
+  multiLocaleSearch: multiLocaleSearchProp,
 }) => {
   const { t, i18n } = useTranslation();
   const language = useMemo(
     () => normalizeLanguage(i18n.language),
     [i18n.language],
   );
+  const contextMultiLocaleSearch = useMultiLocaleSearch();
+  const multiLocaleSearch = multiLocaleSearchProp ?? contextMultiLocaleSearch;
   const typedItemMatch = useMemo(
     () =>
       findItemByName(
         value,
         language,
         allPokemonAndItems ? undefined : gameVersionId,
+        multiLocaleSearch,
       ),
-    [allPokemonAndItems, gameVersionId, language, value],
+    [allPokemonAndItems, gameVersionId, language, multiLocaleSearch, value],
   );
   const resolvedSlug = selectedSlug || typedItemMatch?.slug || "";
   const spriteUrl = resolvedSlug ? getItemSpriteUrl(resolvedSlug) : null;
@@ -58,9 +64,10 @@ const ItemSuggestionInput: React.FC<ItemSuggestionInputProps> = ({
           language,
           allPokemonAndItems ? undefined : gameVersionId,
           20,
+          multiLocaleSearch,
         ),
       ),
-    [allPokemonAndItems, gameVersionId, language],
+    [allPokemonAndItems, gameVersionId, language, multiLocaleSearch],
   );
 
   useEffect(() => {

--- a/src/components/inputs/LocationSuggestionInput.tsx
+++ b/src/components/inputs/LocationSuggestionInput.tsx
@@ -1,11 +1,13 @@
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   searchLocations,
+  findLocationByName,
   type LocationSearchResult,
 } from "@/src/services/locationSearch.ts";
 import { normalizeLanguage } from "@/src/utils/language.ts";
 import SuggestionInput from "@/src/components/inputs/SuggestionInput.tsx";
+import { useMultiLocaleSearch } from "@/src/hooks/useMultiLocaleSearch.ts";
 
 interface LocationSuggestionInputProps {
   label: string;
@@ -23,6 +25,7 @@ const LocationSuggestionInput: React.FC<LocationSuggestionInputProps> = ({
   label,
   value,
   onChange,
+  selectedSlug,
   onSelectedSlugChange,
   isOpen,
   gameVersionId,
@@ -34,14 +37,30 @@ const LocationSuggestionInput: React.FC<LocationSuggestionInputProps> = ({
     () => normalizeLanguage(i18n.language),
     [i18n.language],
   );
+  const multiLocaleSearch = useMultiLocaleSearch();
+  const typedLocationMatch = useMemo(
+    () =>
+      findLocationByName(value, {
+        locale: language,
+        gameVersionId,
+        multiLocaleSearch,
+      }),
+    [gameVersionId, language, multiLocaleSearch, value],
+  );
   const fetchSuggestions = useCallback(
     (term: string) =>
       searchLocations(term, 1000, {
         locale: language,
         gameVersionId,
+        multiLocaleSearch,
       }),
-    [gameVersionId, language],
+    [gameVersionId, language, multiLocaleSearch],
   );
+
+  useEffect(() => {
+    if (!typedLocationMatch || typedLocationMatch.slug === selectedSlug) return;
+    onSelectedSlugChange?.(typedLocationMatch.slug);
+  }, [onSelectedSlugChange, selectedSlug, typedLocationMatch]);
 
   return (
     <SuggestionInput<LocationSearchResult>

--- a/src/components/inputs/PokemonSuggestionInput.tsx
+++ b/src/components/inputs/PokemonSuggestionInput.tsx
@@ -4,6 +4,7 @@ import { searchPokemonNames } from "@/src/services/pokemonSearch.ts";
 import { getSpriteUrlForPokemonName } from "@/src/services/sprites.ts";
 import { normalizeLanguage } from "@/src/utils/language.ts";
 import SuggestionInput from "@/src/components/inputs/SuggestionInput.tsx";
+import { useMultiLocaleSearch } from "@/src/hooks/useMultiLocaleSearch.ts";
 
 interface PokemonSuggestionInputProps {
   label?: React.ReactNode;
@@ -12,6 +13,7 @@ interface PokemonSuggestionInputProps {
   isOpen: boolean;
   generationLimit?: number;
   generationSpritePath?: string | null;
+  multiLocaleSearch?: boolean;
 }
 
 const PokemonSuggestionInput: React.FC<PokemonSuggestionInputProps> = ({
@@ -21,20 +23,29 @@ const PokemonSuggestionInput: React.FC<PokemonSuggestionInputProps> = ({
   isOpen,
   generationLimit,
   generationSpritePath,
+  multiLocaleSearch: multiLocaleSearchProp,
 }) => {
   const { t, i18n } = useTranslation();
   const language = useMemo(
     () => normalizeLanguage(i18n.language),
     [i18n.language],
   );
-  const spriteUrl = getSpriteUrlForPokemonName(value, generationSpritePath);
+  const contextMultiLocaleSearch = useMultiLocaleSearch();
+  const multiLocaleSearch = multiLocaleSearchProp ?? contextMultiLocaleSearch;
+  const spriteLocale = multiLocaleSearch ? undefined : language;
+  const spriteUrl = getSpriteUrlForPokemonName(
+    value,
+    generationSpritePath,
+    spriteLocale,
+  );
   const fetchSuggestions = useCallback(
     (term: string) =>
       searchPokemonNames(term, 10, {
         maxGeneration: generationLimit,
         locale: language,
+        multiLocaleSearch,
       }),
-    [generationLimit, language],
+    [generationLimit, language, multiLocaleSearch],
   );
 
   return (

--- a/src/components/modals/TrackerSearchModal.tsx
+++ b/src/components/modals/TrackerSearchModal.tsx
@@ -118,6 +118,7 @@ const TrackerSearchModal: React.FC<TrackerSearchModalProps> = ({
       locationMatchesQuery(locationLabel, normalizedQuery, {
         locale,
         gameVersionId,
+        multiLocaleSearch,
       })
     ) {
       return true;
@@ -164,6 +165,7 @@ const TrackerSearchModal: React.FC<TrackerSearchModalProps> = ({
     gameVersionId,
     graveyard,
     locale,
+    multiLocaleSearch,
     team,
     t,
     matchingFamilyIds,
@@ -279,13 +281,14 @@ const TrackerSearchModal: React.FC<TrackerSearchModalProps> = ({
             locationMatchesQuery(item.location, normalizedQuery, {
               locale,
               gameVersionId,
+              multiLocaleSearch,
             })
           );
         });
         return { key, title: t(titleKey), items };
       })
       .filter((section) => section.items.length > 0);
-  }, [allItems, gameVersionId, locale, normalizedQuery, t]);
+  }, [allItems, gameVersionId, locale, multiLocaleSearch, normalizedQuery, t]);
 
   const hasPokemonResults = pokemonSections.length > 0;
   const hasItemResults = itemSections.length > 0;

--- a/src/components/modals/TrackerSearchModal.tsx
+++ b/src/components/modals/TrackerSearchModal.tsx
@@ -19,6 +19,7 @@ import {
   resolvePokemonLocationDisplay,
 } from "@/src/services/locationSearch";
 import { normalizeLanguage } from "@/src/utils/language";
+import { useMultiLocaleSearch } from "@/src/hooks/useMultiLocaleSearch.ts";
 
 type SearchMode = "pokemon" | "items";
 type PokemonSectionKey = "team" | "box" | "graveyard";
@@ -79,6 +80,7 @@ const TrackerSearchModal: React.FC<TrackerSearchModalProps> = ({
   const [mode, setMode] = useState<SearchMode>("pokemon");
   const [query, setQuery] = useState("");
   const locale = normalizeLanguage(i18n.language);
+  const multiLocaleSearch = useMultiLocaleSearch();
 
   useEffect(() => {
     if (!isOpen) return;
@@ -95,9 +97,12 @@ const TrackerSearchModal: React.FC<TrackerSearchModalProps> = ({
   const matchingFamilyIds = useMemo(
     () =>
       normalizedQuery
-        ? getPokemonFamilyIdsMatchingQuery(normalizedQuery)
+        ? getPokemonFamilyIdsMatchingQuery(normalizedQuery, {
+            locale,
+            multiLocaleSearch,
+          })
         : new Set<number>(),
-    [normalizedQuery],
+    [normalizedQuery, locale, multiLocaleSearch],
   );
 
   const matchesPokemonQuery = (pair: PokemonLink) => {

--- a/src/components/pages/UserSettingsPage.tsx
+++ b/src/components/pages/UserSettingsPage.tsx
@@ -30,6 +30,8 @@ interface UserSettingsPageProps {
   onSpritesInTeamTableToggle: (enabled: boolean) => void;
   wikiId?: string | null;
   onWikiChange: (id: WikiId) => void;
+  multiLocaleSearch?: boolean;
+  onMultiLocaleSearchToggle: (enabled: boolean) => void;
 }
 
 const UserSettingsPage: React.FC<UserSettingsPageProps> = ({
@@ -42,6 +44,8 @@ const UserSettingsPage: React.FC<UserSettingsPageProps> = ({
   onSpritesInTeamTableToggle,
   wikiId,
   onWikiChange,
+  multiLocaleSearch,
+  onMultiLocaleSearchToggle,
 }) => {
   const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
   const [message, setMessage] = useState<string | null>(null);
@@ -163,6 +167,40 @@ const UserSettingsPage: React.FC<UserSettingsPageProps> = ({
             </p>
             <div className="flex justify-start">
               <LanguageToggle />
+            </div>
+
+            <div className="flex items-center justify-between pt-3">
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <div className="font-medium text-gray-800 dark:text-gray-200">
+                    {t("userSettings.language.multiLocaleSearch.title")}
+                  </div>
+                  <Tooltip
+                    side="top"
+                    content={t(
+                      "userSettings.language.multiLocaleSearch.tooltip",
+                    )}
+                  >
+                    <span
+                      className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 cursor-help"
+                      aria-label={t(
+                        "userSettings.language.multiLocaleSearch.title",
+                      )}
+                    >
+                      <FiInfo size={16} />
+                    </span>
+                  </Tooltip>
+                </div>
+                <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  {t("userSettings.language.multiLocaleSearch.description")}
+                </div>
+              </div>
+              <ToggleSwitch
+                id="multi-locale-search-toggle"
+                checked={multiLocaleSearch ?? false}
+                onChange={onMultiLocaleSearchToggle}
+                ariaLabel={t("userSettings.language.multiLocaleSearch.title")}
+              />
             </div>
           </section>
 

--- a/src/hooks/useMultiLocaleSearch.ts
+++ b/src/hooks/useMultiLocaleSearch.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from "react";
+
+export const MultiLocaleSearchContext = createContext<boolean>(false);
+
+export function useMultiLocaleSearch(): boolean {
+  return useContext(MultiLocaleSearchContext);
+}

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -636,6 +636,12 @@ export const de = {
       title: "Sprache",
       description:
         "Hier kannst du die Sprache der Benutzeroberfläche wechseln.",
+      multiLocaleSearch: {
+        title: "Mehrsprachige Suche",
+        description: "Erlaubt die Suche und Anzeige in verschiedenen Sprachen.",
+        tooltip:
+          "Wenn man irgendwo in Trackern, über Suchfelder nach Pokémon oder Items sucht, kann man auch nach Namen aus anderen Sprachen, als der ausgewählten suchen.",
+      },
     },
     sprites: {
       title: "Sprite-Anzeige",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -629,6 +629,12 @@ export const en = {
     language: {
       title: "Language",
       description: "Choose your preferred interface language below.",
+      multiLocaleSearch: {
+        title: "Multi-language search",
+        description: "Allows searching and resolving in multiple languages.",
+        tooltip:
+          "Whenever you search for Pokémon and Items, anywhere in a tracker, you can search in all languages, in addition to your selected language.",
+      },
     },
     sprites: {
       title: "Sprite Display",

--- a/src/services/itemSearch.ts
+++ b/src/services/itemSearch.ts
@@ -48,6 +48,7 @@ export function searchItems(
   locale: SupportedLanguage = "de",
   gameVersionId?: string,
   max = 10,
+  multiLocaleSearch = false,
 ): ItemSearchResult[] {
   const q = stripDiacritics(query.trim().toLowerCase());
   if (q.length < 1) return [];
@@ -59,14 +60,37 @@ export function searchItems(
   const field = locale === "de" ? "normDe" : "normEn";
   const nameField = locale === "de" ? "de" : "en";
 
-  return ITEM_ENTRIES.filter(
+  const isAvailable = (entry: ItemDataEntry) =>
+    !STONE_SLUGS.has(entry.slug) &&
+    !FOSSIL_SLUGS.has(entry.slug) &&
+    !MEGA_STONE_SLUGS.has(entry.slug) &&
+    (!allowedSlugs || allowedSlugs.has(entry.slug));
+
+  const localResults = ITEM_ENTRIES.filter(
+    (entry) => isAvailable(entry) && entry[field].includes(q),
+  );
+
+  if (!multiLocaleSearch || localResults.length >= max) {
+    return localResults
+      .sort((a, b) => a[nameField].localeCompare(b[nameField]))
+      .slice(0, max)
+      .map((entry) => ({
+        slug: entry.slug,
+        name: entry[nameField],
+        spriteUrl: getSpriteUrl(entry.slug),
+      }));
+  }
+
+  const localSlugs = new Set(localResults.map((entry) => entry.slug));
+  const fallbackField = locale === "de" ? "normEn" : "normDe";
+  const crossResults = ITEM_ENTRIES.filter(
     (entry) =>
-      !STONE_SLUGS.has(entry.slug) &&
-      !FOSSIL_SLUGS.has(entry.slug) &&
-      !MEGA_STONE_SLUGS.has(entry.slug) &&
-      entry[field].includes(q) &&
-      (!allowedSlugs || allowedSlugs.has(entry.slug)),
-  )
+      isAvailable(entry) &&
+      !localSlugs.has(entry.slug) &&
+      entry[fallbackField].includes(q),
+  );
+
+  return [...localResults, ...crossResults]
     .sort((a, b) => a[nameField].localeCompare(b[nameField]))
     .slice(0, max)
     .map((entry) => ({
@@ -80,6 +104,7 @@ export function findItemByName(
   name: string,
   locale: SupportedLanguage = "de",
   gameVersionId?: string,
+  multiLocaleSearch = true,
 ): ItemSearchResult | null {
   const normalizedName = stripDiacritics(name.trim().toLowerCase());
   if (!normalizedName) return null;
@@ -101,10 +126,12 @@ export function findItemByName(
       (entry) =>
         isAvailableEntry(entry) && entry[preferredField] === normalizedName,
     ) ??
-    ITEM_ENTRIES.find(
-      (entry) =>
-        isAvailableEntry(entry) && entry[fallbackField] === normalizedName,
-    );
+    (multiLocaleSearch
+      ? ITEM_ENTRIES.find(
+          (entry) =>
+            isAvailableEntry(entry) && entry[fallbackField] === normalizedName,
+        )
+      : undefined);
 
   return entry
     ? {

--- a/src/services/locationSearch.ts
+++ b/src/services/locationSearch.ts
@@ -8,6 +8,7 @@ const DEFAULT_GAME_VERSION_ID = "gen5_bw";
 interface SearchOptions {
   locale?: SupportedLanguage;
   gameVersionId?: string;
+  multiLocaleSearch?: boolean;
 }
 
 interface LocationEntry {
@@ -164,29 +165,41 @@ export async function searchLocations(
 ): Promise<LocationSearchResult[]> {
   const q = normalizeForSearch(query);
   if (q.length < 2) return [];
-  const { locale = "en", gameVersionId } = options;
+  const { locale = "en", gameVersionId, multiLocaleSearch = false } = options;
   const allowedRegions = getRegionsForVersion(gameVersionId);
   if (!allowedRegions.size) return [];
 
-  const filtered = getLocaleList(locale).filter((entry) => {
+  const isMatchingEntry = (entry: LocationEntry) => {
     const matchesTerm = entry.normalized.includes(q);
-    if (!matchesTerm) return;
-    if (!entry.region || !allowedRegions.has(entry.region)) return;
-    return true;
-  });
+    return matchesTerm && !!entry.region && allowedRegions.has(entry.region);
+  };
 
-  const sorted = sortLocations(filtered);
+  const localResults = getLocaleList(locale).filter(isMatchingEntry);
+  const matchingEntries =
+    multiLocaleSearch && localResults.length < max
+      ? [
+          ...localResults,
+          ...ALL_LOCATION_ENTRIES.filter(
+            (entry) =>
+              !localResults.some(
+                (localEntry) => localEntry.slug === entry.slug,
+              ) && isMatchingEntry(entry),
+          ),
+        ]
+      : localResults;
+
+  const sorted = sortLocations(matchingEntries);
   const unique: LocationEntry[] = [];
-  const seenNames = new Set<string>();
+  const seenSlugs = new Set<string>();
   sorted.forEach((entry) => {
-    if (!seenNames.has(entry.normalized)) {
-      seenNames.add(entry.normalized);
+    if (!seenSlugs.has(entry.slug)) {
+      seenSlugs.add(entry.slug);
       unique.push(entry);
     }
   });
   return unique.slice(0, max).map((entry) => ({
     slug: entry.slug,
-    name: entry.name,
+    name: getEntryBySlug(entry.slug, locale)?.name ?? entry.name,
   }));
 }
 
@@ -211,16 +224,25 @@ export function findLocationByName(
   const normalizedName = normalizeForSearch(name ?? "");
   if (!normalizedName) return null;
 
-  const { locale = DEFAULT_LOCATION_LOCALE, gameVersionId } = options;
+  const {
+    locale = DEFAULT_LOCATION_LOCALE,
+    gameVersionId,
+    multiLocaleSearch = false,
+  } = options;
   const allowedRegions = getRegionsForVersion(gameVersionId);
 
-  const found = ALL_LOCATION_ENTRIES.find((entry) => {
+  const isMatchingEntry = (entry: LocationEntry) => {
     if (!entry.region || !allowedRegions.has(entry.region)) return false;
     return (
       entry.normalized === normalizedName ||
       normalizeForSearch(entry.slug) === normalizedName
     );
-  });
+  };
+  const found =
+    getLocaleList(locale).find(isMatchingEntry) ??
+    (multiLocaleSearch
+      ? ALL_LOCATION_ENTRIES.find(isMatchingEntry)
+      : undefined);
   const displayEntry = found ? getEntryBySlug(found.slug, locale) : null;
 
   return found
@@ -237,17 +259,21 @@ export function locationMatchesQuery(
   if (!normalizedQuery) return true;
 
   const normalizedLocationName = normalizeForSearch(locationName ?? "");
-  if (normalizedLocationName.includes(normalizedQuery)) return true;
+  const matchedLocation = findLocationByName(locationName, {
+    ...options,
+    multiLocaleSearch: true,
+  });
+  if (!matchedLocation) return normalizedLocationName.includes(normalizedQuery);
 
-  const matchedLocation = findLocationByName(locationName, options);
-  if (!matchedLocation) return false;
+  const { locale = DEFAULT_LOCATION_LOCALE, multiLocaleSearch = false } =
+    options;
+  const entries = multiLocaleSearch
+    ? getEntriesBySlug(matchedLocation.slug)
+    : [getEntryBySlug(matchedLocation.slug, locale)].filter(
+        (entry): entry is LocationEntry => !!entry,
+      );
 
-  return (
-    normalizeForSearch(matchedLocation.slug).includes(normalizedQuery) ||
-    getEntriesBySlug(matchedLocation.slug).some((entry) =>
-      entry.normalized.includes(normalizedQuery),
-    )
-  );
+  return entries.some((entry) => entry.normalized.includes(normalizedQuery));
 }
 
 export function resolvePokemonLocationDisplay(

--- a/src/services/pokemonSearch.ts
+++ b/src/services/pokemonSearch.ts
@@ -4,6 +4,7 @@ import { SUPPORTED_LANGUAGES, SupportedLanguage } from "@/src/utils/language";
 interface SearchOptions {
   maxGeneration?: number;
   locale?: SupportedLanguage;
+  multiLocaleSearch?: boolean;
 }
 
 type PokemonNameEntry = {
@@ -72,6 +73,11 @@ SUPPORTED_LANGUAGES.forEach((locale) => {
   });
 });
 
+const LOCALE_NAME_TO_ID: Record<SupportedLanguage, Record<string, number>> = {
+  de: Object.fromEntries(NAME_LISTS.de.map(({ lower, id }) => [lower, id])),
+  en: Object.fromEntries(NAME_LISTS.en.map(({ lower, id }) => [lower, id])),
+};
+
 export async function searchPokemonNames(
   query: string,
   max = 10,
@@ -79,17 +85,45 @@ export async function searchPokemonNames(
 ): Promise<string[]> {
   const q = query.trim().toLowerCase();
   if (q.length < 2) return [];
-  const { maxGeneration, locale = "de" } = options;
+  const { maxGeneration, locale = "de", multiLocaleSearch = false } = options;
   const list = NAME_LISTS[locale] || NAME_LISTS.de;
-  return list
-    .filter(
-      (entry) =>
+
+  const genFilter = (generation: number) =>
+    typeof maxGeneration !== "number" || generation <= maxGeneration;
+
+  const localMatches = list.filter(
+    (entry) => entry.lower.includes(q) && genFilter(entry.generation),
+  );
+  const localResults = localMatches.slice(0, max).map((entry) => entry.name);
+
+  if (!multiLocaleSearch || localResults.length >= max) {
+    return localResults;
+  }
+
+  // Cross-locale: find matching IDs from other locales, return current-locale names
+  const localIds = new Set(localMatches.map((entry) => entry.id));
+
+  const crossLocaleIds = new Set<number>();
+  SUPPORTED_LANGUAGES.forEach((lang) => {
+    if (lang === locale) return;
+    (NAME_LISTS[lang] || []).forEach((entry) => {
+      if (
         entry.lower.includes(q) &&
-        (typeof maxGeneration !== "number" ||
-          entry.generation <= maxGeneration),
-    )
-    .slice(0, max)
-    .map((entry) => entry.name);
+        genFilter(entry.generation) &&
+        !localIds.has(entry.id)
+      ) {
+        crossLocaleIds.add(entry.id);
+      }
+    });
+  });
+
+  const idToName = ID_TO_NAME[locale] || ID_TO_NAME.de;
+  const crossResults = Array.from(crossLocaleIds)
+    .map((id) => idToName[id])
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b, locale));
+
+  return [...localResults, ...crossResults].slice(0, max);
 }
 
 function collectPokemonFamilyIds(id: number): Set<number> {
@@ -121,8 +155,12 @@ export function getPokemonFamilyIdsMatchingQuery(
   const q = query.trim().toLowerCase();
   if (!q) return new Set<number>();
 
-  const { maxGeneration } = options;
-  return ALL_NAME_ENTRIES.reduce<Set<number>>((acc, entry) => {
+  const { maxGeneration, locale, multiLocaleSearch = true } = options;
+  const entries =
+    !multiLocaleSearch && locale
+      ? NAME_LISTS[locale] || NAME_LISTS.de
+      : ALL_NAME_ENTRIES;
+  return entries.reduce<Set<number>>((acc, entry) => {
     if (!entry.lower.includes(q)) return acc;
     if (typeof maxGeneration === "number" && entry.generation > maxGeneration) {
       return acc;
@@ -134,10 +172,16 @@ export function getPokemonFamilyIdsMatchingQuery(
 
 export function findPokemonIdByName(
   name: string | undefined | null,
+  locale?: SupportedLanguage,
 ): PokemonNameMatch | null {
   if (!name) return null;
   const key = name.trim().toLowerCase();
   if (!key) return null;
+  if (locale) {
+    const id = LOCALE_NAME_TO_ID[locale]?.[key];
+    if (typeof id === "number") return { id, language: locale };
+    return null;
+  }
   return MERGED_NAME_TO_ID[key] || null;
 }
 

--- a/src/services/sprites.ts
+++ b/src/services/sprites.ts
@@ -1,4 +1,5 @@
 import { findPokemonIdByName } from "@/src/services/pokemonSearch";
+import type { SupportedLanguage } from "@/src/utils/language";
 
 // Map game version IDs to PokeAPI sprite generation paths
 export function getGenerationSpritePath(gameVersionId: string): string | null {
@@ -151,8 +152,9 @@ export function getSpriteUrlById(
 export function getSpriteUrlForPokemonName(
   name: string | undefined | null,
   generationPath?: string | null,
+  locale?: SupportedLanguage,
 ): string | null {
-  const match = findPokemonIdByName(name);
+  const match = findPokemonIdByName(name, locale);
   if (!match) return null;
   return getSpriteUrlById(match.id, generationPath);
 }

--- a/src/services/trackers.ts
+++ b/src/services/trackers.ts
@@ -448,3 +448,19 @@ export const getUserWikiPreference = async (
   const snapshot = await get(ref(db, userPath));
   return snapshot.exists() ? (snapshot.val() as string) : null;
 };
+
+export const updateUserMultiLocaleSearchPreference = async (
+  userId: string,
+  multiLocaleSearch: boolean,
+): Promise<void> => {
+  const userPath = `users/${userId}/multiLocaleSearch`;
+  await set(ref(db, userPath), multiLocaleSearch);
+};
+
+export const getUserMultiLocaleSearchPreference = async (
+  userId: string,
+): Promise<boolean> => {
+  const userPath = `users/${userId}/multiLocaleSearch`;
+  const snapshot = await get(ref(db, userPath));
+  return snapshot.exists() ? snapshot.val() : false;
+};


### PR DESCRIPTION
Reevaluated suggestions and search for Pokémon and Items:
- Both are only suggested in the selected language
- Images are only shown, if the name is resolved in the correct language
- Added toggle to overwite this behaviour, so every every language can be searched
- Global search also applies to the same toggle